### PR TITLE
Change walkdirfn callback to return skipdir boolean and error

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,22 +84,26 @@ for pathname, entry, isdir, err in walkdir('/tmp', true) do
 end
 ```
 
-## err = walkdir( pathname [, follow_symlink [, walkerfn]] )
+Also, you can pass a `walkerfn` function to the `walkdir` function to control the traversal behavior
+
+### err = walkdir( pathname [, follow_symlink [, walkerfn]] )
 
 If `walkerfn` is provided, the function will traverse the directory and call the `walkerfn` for each entry.
 
 **Parameters**
 
-- `pathname:string`: the directory to traverse.
-- `follow_symlink:boolean`: follow symbolic links. (default: `false`)
 - `walkerfn:function`: a function that will be called for each entry in the directory.
     ```
-    walkerfn(pathname:string, entry:string, isdir:boolean):(allowdir:boolean)
+    walkerfn(pathname:string, entry:string, isdir:boolean):(skipdir:boolean, err:any)
 
+    Parameters:
     * pathname: the entry's pathname.
     * entry: the entry's name.
     * isdir: whether the entry is a directory.
-    * allowdir: If `false`, the directory will not be traversed further, otherwise it will be traversed.
+
+    Returns:
+    * skipdir: If `true`, the directory will not be traversed further, otherwise it will be traversed.
+    * err: an error object if an error occurred during traversal. If an error returned, the traversal will stop and the error will be returned by the `walkdir` function.
     ```
 
 **Returns**

--- a/test/walkdir_test.lua
+++ b/test/walkdir_test.lua
@@ -137,19 +137,23 @@ function testcase.with_walkerfn()
         assert.is_string(entry)
         assert.is_boolean(is_dir)
         if pathname == skipdir then
-            return false -- skip skipdir
+            return true -- skip skipdir
         end
         -- remove pathname
         entries[pathname] = nil
-        return true
     end)
     assert.is_nil(err)
-
     -- confirm that the skipped directory is exists
     for pathname in pairs(entries) do
         local basedir = string.sub(pathname, 1, #skipdir)
         assert.equal(basedir, skipdir)
     end
+
+    -- test that the walkerfn returns an error
+    err = walkdir('./testdir', true, function()
+        return nil, 'error in walkerfn'
+    end)
+    assert.match(err, 'error in walkerfn')
 
     -- test that throws error when walkerfn is not a function
     err = assert.throws(walkdir, './testdir', true, 123)


### PR DESCRIPTION
This pull request updates the `walkdir` function to improve its handling of directory traversal with a custom `walkerfn` function. The changes include renaming and redefining the return values of `walkerfn` to provide more clarity and functionality, adding error handling, and updating documentation and tests to reflect these changes.

### Updates to `walkdir` function behavior:

* **Renaming return values of `walkerfn`:** The `walkerfn` function now returns `skipdir` (instead of `allowdir`) and an optional `err` object. This change clarifies the behavior by explicitly indicating whether a directory should be skipped and allowing error propagation during traversal. (`README.md` - [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R106) `walkdir.lua` - [[2]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L144-R144)
* **Error handling in `walkerfn`:** The `walkdir` function now stops traversal and returns an error if the `walkerfn` function returns an error object. (`walkdir.lua` - [walkdir.luaL161-R170](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L161-R170))

### Documentation updates:

* **Enhanced documentation for `walkerfn`:** Updated the README to reflect the new return values (`skipdir` and `err`) and their behavior. This includes adding a detailed explanation of the parameters and return values. (`README.md` - [README.mdL87-R106](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R106))

### Test updates:

* **Additional test cases for `walkerfn`:** Added tests to verify the new behavior of `walkerfn`, including handling errors and ensuring directories are skipped correctly based on the `skipdir` return value. (`test/walkdir_test.lua` - [test/walkdir_test.luaL140-R157](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L140-R157))