### PR TITLE
Change the order of return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ luarocks install walkdir
 ```lua
 local walkdir = require('walkdir')
 -- traverse a /tmp directory and print each entry
-for pathname, entry, isdir in walkdir('/tmp', true) do
-    print(pathname, entry, isdir)
+for pathname, err, entry, isdir in walkdir('/tmp', true) do
+    print(pathname, err, entry, isdir)
 end
 ```
 
@@ -40,14 +40,14 @@ Get an iterator function and context for traversing a specified directory.
 
 - `iter:function`: an iterator function that returns the next entry in the directory.
     ```
-    pathname:string, entry:string, isdir:boolean, err:any = iter(ctx:table)
+    pathname:string, err:any, entry:string, isdir:boolean = iter(ctx:table)
 
     * pathname: the entry's pathname.
+    * err: an error object if an error occurred during traversal.
     * entry: the entry's name.
     * isdir: whether the entry is a directory.
-    * err: an error object if an error occurred during traversal.
     ```
-    - **NOTE:** if an error occurs during traversal, the iterator returns an empty string `''`, `nil`, `nil`, and the error object. On subsequent calls, it consistently returns `nil`, `nil`, `nil`, and the same error object.
+    - **NOTE:** if an error occurs during traversal, the iterator returns an empty string `''` and the error object. On subsequent calls, it consistently returns `nil` and the same error object.
 - `ctx:table`: a context table that contains the following fields:
     - `pathname:string`: the current pathname of the directory being traversed.
     - `follow_symlink:boolean`: whether symbolic links are followed.
@@ -65,19 +65,19 @@ local walkdir = require('walkdir')
 
 -- get an iterator function and context for traversing a /tmp directory
 local iter, ctx = walkdir('/tmp', true)
-local pathname, entry, isdir, err = iter(ctx)
+local pathname, err, entry, isdir = iter(ctx)
 while pathname do
-    print(pathname, entry, isdir, err)
+    print(pathname, err, entry, isdir)
     if err then
         print('Error:', err)
     end
     -- read next entry
-    pathname, entry, isdir, err = iter(ctx)
+    pathname, err, entry, isdir = iter(ctx)
 end
 
 -- or using a generic for loop
-for pathname, entry, isdir, err in walkdir('/tmp', true) do
-    print(pathname, entry, isdir, err)
+for pathname, err, entry, isdir in walkdir('/tmp', true) do
+    print(pathname, err, entry, isdir)
     if err then
         print('Error:', err)
     end
@@ -131,5 +131,4 @@ if err then
     print('Error:', err)
 end
 ```
-
 

--- a/test/walkdir_test.lua
+++ b/test/walkdir_test.lua
@@ -80,7 +80,7 @@ function testcase.call_iterator_function()
 
     -- test that the iterator function returns entries in the directory
     local entries = copy_entries()
-    local pathname, entry, is_dir, err = iter(ctx)
+    local pathname, err, entry, is_dir = iter(ctx)
     while pathname do
         assert.is_string(pathname)
         assert.is_string(entry)
@@ -94,7 +94,7 @@ function testcase.call_iterator_function()
         entries[pathname] = nil
 
         -- get next entry
-        pathname, entry, is_dir, err = iter(ctx)
+        pathname, err, entry, is_dir = iter(ctx)
     end
 
     -- confirm that there is no error
@@ -111,8 +111,9 @@ function testcase.with_generic_for_loop()
     local entries = copy_entries()
 
     -- test that call walkdir with generic for loop
-    for pathname, entry, is_dir in walkdir('./testdir') do
+    for pathname, err, entry, is_dir in walkdir('./testdir') do
         assert.is_string(pathname)
+        assert.is_nil(err)
         assert.is_string(entry)
         assert.is_boolean(is_dir)
         -- confirm that the entry is last part of pathname
@@ -177,30 +178,30 @@ end
 function testcase.pathname_that_does_not_exist()
     -- test that iterator returns nil when pathname does not exist
     local iter, ctx = walkdir('./unknown_dir')
-    local pathname, entry, is_dir, err = iter(ctx)
+    local pathname, err, entry, is_dir = iter(ctx)
     assert.is_nil(pathname)
+    assert.is_nil(err)
     assert.is_nil(entry)
     assert.is_nil(is_dir)
-    assert.is_nil(err)
 end
 
 function testcase.pathname_that_is_not_a_directory()
     -- test that iterator returns error when pathname is not a directory
     local iter, ctx = walkdir('./testdir/1.txt')
-    local pathname, entry, is_dir, err = iter(ctx)
+    local pathname, err, entry, is_dir = iter(ctx)
     assert.equal(pathname, '')
+    assert.match(err, 'ENOTDIR')
     assert.is_nil(entry)
     assert.is_nil(is_dir)
-    assert.match(err, 'ENOTDIR')
 
     -- test that iterator returns only same error on subsequent calls
     for _ = 1, 3 do
         local err2
-        pathname, entry, is_dir, err2 = iter(ctx)
+        pathname, err2, entry, is_dir = iter(ctx)
         assert.is_nil(pathname)
+        assert.equal(err, err2)
         assert.is_nil(entry)
         assert.is_nil(is_dir)
-        assert.equal(err, err2)
     end
 end
 


### PR DESCRIPTION
This pull request updates the `walkdir` library to improve error handling and streamline the order of return values in its iterator functions. The changes ensure that errors are consistently returned as the second value, making the API easier to use and enhancing clarity in documentation and tests.

### Updates to `README.md`:

* Adjusted examples to reflect the new return value order (`pathname, err, entry, isdir`) in iterator functions. Error handling is now more explicit in code examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R21) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R50) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R80)

### Updates to `walkdir.lua`:

* Refactored the `read_next_entry` function to return errors as the second value, simplifying error propagation and improving consistency. Updated internal logic to align with this change.
* Modified `walkdir_with_walkerfn` to use the new return value order (`pathname, err, entry, isdir`), ensuring compatibility with the updated iterator logic. [[1]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L152-R165) [[2]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L175-R179)

### Updates to `test/walkdir_test.lua`:

* Updated test cases to validate the new return value order and ensure proper error handling. Added assertions for error values where applicable. [[1]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L83-R83) [[2]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L97-R97) [[3]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L114-R116) [[4]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L180-L203)