### PR TITLE
Add file stat as additional return value to read_next_entry

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,4 +3,6 @@ include_files = {
     "walkdir.lua",
     "test/**/*_test.lua",
 }
-ignore = {}
+ignore = {
+    '631', -- ignore line is too long
+}

--- a/README.md
+++ b/README.md
@@ -40,15 +40,21 @@ Get an iterator function and context for traversing a specified directory.
 
 - `iter:function`: an iterator function that returns the next entry in the directory.
     ```
-    pathname:string, err:any, entry:string, isdir:boolean, depth:integer = iter(ctx:table)
+    pathname:string, err:any, entry:string, isdir:boolean, depth:integer, stat:table = iter(ctx:table)
 
-    * pathname: the entry's pathname.
-    * err: an error object if an error occurred during traversal.
-    * entry: the entry's name.
-    * isdir: whether the entry is a directory.
-    * depth: the depth of the entry in the directory tree, starting from 1 for the root directory and incrementing for each subdirectory.
+    * pathname  : the entry's pathname.
+    * err       : an error object if an error occurred during traversal.
+    * entry     : the entry's name.
+    * isdir     : whether the entry is a directory.
+    * depth     : the depth of the entry in the directory tree, starting from 1 
+                  for the root directory and incrementing for each subdirectory.
+    * stat      : a table containing file status information (e.g., size, 
+                  modification time). if fail to get the file stat, it contains 
+                  an `error` field with the error object.
     ```
-    - **NOTE:** if an error occurs during traversal, the iterator returns an empty string `''` and the error object. On subsequent calls, it consistently returns `nil` and the same error object.
+    - **NOTE:** if an error occurs during traversal, the iterator returns an 
+                empty string `''` and the error object. On subsequent calls, 
+                it consistently returns `nil` and the same error object.
 - `ctx:table`: a context table that contains the following fields:
     - `pathname:string`: the current pathname of the directory being traversed.
     - `depth:integer`: the current depth in the directory tree, starting from 1 for the root directory and incrementing for each subdirectory.
@@ -68,19 +74,19 @@ local walkdir = require('walkdir')
 
 -- get an iterator function and context for traversing a /tmp directory
 local iter, ctx = walkdir('/tmp', true)
-local pathname, err, entry, isdir, depth = iter(ctx)
+local pathname, err, entry, isdir, depth, stat = iter(ctx)
 while pathname do
-    print(pathname, err, entry, isdir, depth)
+    print(pathname, err, entry, isdir, depth, stat)
     if err then
         print('Error:', err)
     end
     -- read next entry
-    pathname, err, entry, isdir, depth = iter(ctx)
+    pathname, err, entry, isdir, depth, stat = iter(ctx)
 end
 
 -- or using a generic for loop
-for pathname, err, entry, isdir, depth in walkdir('/tmp', true) do
-    print(pathname, err, entry, isdir, depth)
+for pathname, err, entry, isdir, depth, stat in walkdir('/tmp', true) do
+    print(pathname, err, entry, isdir, depth, stat)
     if err then
         print('Error:', err)
     end
@@ -97,17 +103,24 @@ If `walkerfn` is provided, the function will traverse the directory and call the
 
 - `walkerfn:function`: a function that will be called for each entry in the directory.
     ```
-    walkerfn(pathname:string, entry:string, isdir:boolean, depth:integer):(skipdir:boolean, err:any)
+    walkerfn(pathname:string, entry:string, isdir:boolean, depth:integer, stat:table):(skipdir:boolean, err:any)
 
     Parameters:
-    * pathname: the entry's pathname.
-    * entry: the entry's name.
-    * isdir: whether the entry is a directory.
-    * depth: the depth of the entry in the directory tree, starting from 1 for the root directory and incrementing for each subdirectory.
+    * pathname  : the entry's pathname.
+    * entry     : the entry's name.
+    * isdir     : whether the entry is a directory.
+    * depth     : the depth of the entry in the directory tree, starting from 1 
+                  for the root directory and incrementing for each subdirectory.
+    * stat      : a table containing file status information (e.g., size, 
+                  modification time). if fail to get the file stat, it contains 
+                  an `error` field with the error object.
 
     Returns:
-    * skipdir: If `true`, the directory will not be traversed further, otherwise it will be traversed.
-    * err: an error object if an error occurred during traversal. If an error returned, the traversal will stop and the error will be returned by the `walkdir` function.
+    * skipdir   : If `true`, the directory will not be traversed further, 
+                  otherwise it will be traversed.
+    * err       : an error object if an error occurred during traversal. If an 
+                  error returned, the traversal will stop and the error will be 
+                  returned by the `walkdir` function.
     ```
 
 **Returns**
@@ -122,8 +135,8 @@ the following example shows how to use the `walkdir` function to traverse a dire
 local walkdir = require('walkdir')
 
 -- traverse a /tmp directory and call the walker function for each entry
-local err = walkdir('/tmp', true, function(pathname, entry, isdir, depth)
-    print(pathname, entry, isdir, depth)
+local err = walkdir('/tmp', true, function(pathname, entry, isdir, depth, stat)
+    print(pathname, entry, isdir, depth, stat)
     -- if the entry is a directory and only want to traverse directories up to depth 2
     if isdir and depth == 2 then
         -- skip traversing this directory

--- a/test/walkdir_test.lua
+++ b/test/walkdir_test.lua
@@ -85,13 +85,14 @@ function testcase.call_iterator_function()
 
     -- test that the iterator function returns entries in the directory
     local entries = copy_entries()
-    local pathname, err, entry, is_dir, depth = iter(ctx)
+    local pathname, err, entry, is_dir, depth, stat = iter(ctx)
     while pathname do
         assert.is_string(pathname)
         assert.is_nil(err)
         assert.is_string(entry)
         assert.is_boolean(is_dir)
         assert.is_int(depth)
+        assert.is_table(stat)
         -- confirm that the entry is last part of pathname
         assert.equal(pathname:match('([^/]+)$'), entry)
 
@@ -122,12 +123,13 @@ function testcase.with_generic_for_loop()
 
     -- test that call walkdir with generic for loop
     local rootdir = './testdir'
-    for pathname, err, entry, is_dir, depth in walkdir(rootdir) do
+    for pathname, err, entry, is_dir, depth, stat in walkdir(rootdir) do
         assert.is_string(pathname)
         assert.is_nil(err)
         assert.is_string(entry)
         assert.is_boolean(is_dir)
         assert.is_int(depth)
+        assert.is_table(stat)
         -- confirm that the entry is last part of pathname
         assert.equal(pathname:match('([^/]+)$'), entry)
         -- confirm that the depth is correct
@@ -149,11 +151,12 @@ function testcase.with_walkerfn()
     -- test that walkdir with walker function
     local skipdir = './testdir/foo/bar/baz/qux'
     local err = walkdir('./testdir', true,
-                        function(pathname, entry, is_dir, depth)
+                        function(pathname, entry, is_dir, depth, stat)
         assert.is_string(pathname)
         assert.is_string(entry)
         assert.is_boolean(is_dir)
         assert.is_int(depth)
+        assert.is_table(stat)
         if pathname == skipdir then
             return true -- skip skipdir
         end
@@ -195,30 +198,36 @@ end
 function testcase.pathname_that_does_not_exist()
     -- test that iterator returns nil when pathname does not exist
     local iter, ctx = walkdir('./unknown_dir')
-    local pathname, err, entry, is_dir = iter(ctx)
+    local pathname, err, entry, is_dir, depth, stat = iter(ctx)
     assert.is_nil(pathname)
     assert.is_nil(err)
     assert.is_nil(entry)
     assert.is_nil(is_dir)
+    assert.is_nil(depth)
+    assert.is_nil(stat)
 end
 
 function testcase.pathname_that_is_not_a_directory()
     -- test that iterator returns error when pathname is not a directory
     local iter, ctx = walkdir('./testdir/1.txt')
-    local pathname, err, entry, is_dir = iter(ctx)
+    local pathname, err, entry, is_dir, depth, stat = iter(ctx)
     assert.equal(pathname, '')
     assert.match(err, 'ENOTDIR')
     assert.is_nil(entry)
     assert.is_nil(is_dir)
+    assert.is_nil(depth)
+    assert.is_nil(stat)
 
     -- test that iterator returns only same error on subsequent calls
     for _ = 1, 3 do
         local err2
-        pathname, err2, entry, is_dir = iter(ctx)
+        pathname, err2, entry, is_dir, depth, stat = iter(ctx)
         assert.is_nil(pathname)
         assert.equal(err, err2)
         assert.is_nil(entry)
         assert.is_nil(is_dir)
+        assert.is_nil(depth)
+        assert.is_nil(stat)
     end
 end
 


### PR DESCRIPTION
This pull request introduces enhancements to the `walkdir` library by adding file status information (`stat`) to directory traversal functions, improving functionality and documentation. It also updates tests and configurations to reflect these changes. Below are the most important changes, grouped by theme:

### Core Functionality Enhancements:
- **`walkdir.lua`:** Updated `read_next_entry` and `isdir` functions to include `stat` (file status information) in their return values. This enables users to access detailed file metadata during traversal, such as size and modification time. [[1]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0R32-R48) [[2]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L129-R145)
- **`walkdir.lua`:** Modified `walkdir_with_walkerfn` and iterator functions to pass the `stat` object to the walker function and iterator, ensuring consistency across traversal methods. [[1]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L155-R165) [[2]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L165-R175) [[3]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L189-R205)

### Documentation Updates:
- **`README.md`:** Updated examples and documentation to include `stat` in iterator function signatures and walker function parameters. Added explanations about the `stat` table and its fields. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R57) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R123) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L125-R139)

### Test Suite Updates:
- **`test/walkdir_test.lua`:** Updated test cases to validate the inclusion of `stat` in iterator and walker function outputs. Added assertions to ensure `stat` is a table and behaves correctly in various scenarios. [[1]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L88-R95) [[2]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L125-R132) [[3]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L152-R159) [[4]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4L198-R230)

### Configuration Changes:
- **`.luacheckrc`:** Added an ignore rule for long lines (`631`) to accommodate updated documentation and examples.

These changes collectively improve the usability and extensibility of the `walkdir` library while maintaining backward compatibility.