### PR TITLE
Update opendir dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,14 @@ on:
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua
-      uses: mah0x211/setup-lua@v1
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -28,6 +27,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
@@ -38,15 +39,15 @@ jobs:
           - "lj-v2.1:latest"
     steps:
     -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
+    -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: mah0x211/setup-lua@v1
-      with:
-        versions: ${{ matrix.lua-version }}
     -
       name: Install Test Dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -27,14 +27,88 @@ end
 the following functions return the `error` object created by https://github.com/mah0x211/lua-errno module.
 
 
-## iter, ctx = walkdir( pathname [, follow_symlink]] )
+## ... = walkdir( pathname [, follow_symlink [, walkerfn [, toctou]]] )
 
-Get an iterator function and context for traversing a specified directory.
+When `walkerfn` is provided, `walkdir` traverses immediately and uses callback style. When `walkerfn` is omitted, `walkdir` returns an iterator and context.
 
 **Parameters**
 
 - `pathname:string`: the directory to traverse.
 - `follow_symlink:boolean`: follow symbolic links. (default: `false`)
+- `walkerfn:function`: a function that will be called for each entry in the directory.
+- `toctou:boolean`: if `true`, use `openat(2)` for each path segment to prevent TOCTOU (time-of-check/time-of-use) race conditions. When combined with `follow_symlink=false`, symbolic links at **any** position in the path (not just the final component) are rejected with `ENOTDIR`. (default: `false`)
+
+**Returns**
+
+- `...`: Return values depend on whether walkerfn is provided. See below for details.
+
+
+### Callback style
+
+```lua
+err = walkdir(pathname [, follow_symlink], walkerfn [, toctou])
+```
+
+Use this form when you want `walkdir` to traverse immediately and call `walkerfn` for each entry.
+
+`walkerfn:function`: a function that will be called for each entry in the directory.
+
+```
+walkerfn(pathname:string, entry:string, isdir:boolean, depth:integer, stat:table):(skipdir:boolean, err:any)
+
+Parameters:
+* pathname  : the entry's pathname.
+* entry     : the entry's name.
+* isdir     : whether the entry is a directory.
+* depth     : the depth of the entry in the directory tree, starting from 1
+                for the root directory and incrementing for each subdirectory.
+* stat      : a table containing file status information (e.g., size,
+                modification time). if fail to get the file stat, it contains
+                an `error` field with the error object.
+
+Returns:
+* skipdir   : If `true`, the directory will not be traversed further,
+                otherwise it will be traversed.
+* err       : an error object if an error occurred during traversal. If an
+                error returned, the traversal will stop and the error will be
+                returned by the `walkdir` function.
+```
+
+**Returns**
+
+- `err:any`: an error object if an error occurred during traversal. If no error occurred, it returns `nil`.
+
+**Example**
+
+```lua
+local walkdir = require('walkdir')
+
+local err = walkdir('/tmp', true, function(pathname, entry, isdir, depth, stat)
+    print(pathname, entry, isdir, depth, stat)
+    if isdir and depth == 2 then
+        return true
+    end
+end, true)
+
+if err then
+    print('Error:', err)
+end
+```
+
+### Iterator style
+
+```lua
+iter, ctx = walkdir(pathname [, follow_symlink])
+iter, ctx = walkdir(pathname [, follow_symlink], nil, toctou)
+```
+
+Use this form when you want an iterator and context object.
+
+> **Note:** To use `toctou` with the iterator form, pass `nil` as the `walkerfn` placeholder:
+>
+> ```lua
+> local iter, ctx = walkdir('/tmp', false, nil, true)
+> ```
 
 **Returns**
 
@@ -46,105 +120,47 @@ Get an iterator function and context for traversing a specified directory.
     * err       : an error object if an error occurred during traversal.
     * entry     : the entry's name.
     * isdir     : whether the entry is a directory.
-    * depth     : the depth of the entry in the directory tree, starting from 1 
+    * depth     : the depth of the entry in the directory tree, starting from 1
                   for the root directory and incrementing for each subdirectory.
-    * stat      : a table containing file status information (e.g., size, 
-                  modification time). if fail to get the file stat, it contains 
+    * stat      : a table containing file status information (e.g., size,
+                  modification time). if fail to get the file stat, it contains
                   an `error` field with the error object.
     ```
-    - **NOTE:** if an error occurs during traversal, the iterator returns an 
-                empty string `''` and the error object. On subsequent calls, 
+    - **NOTE:** if an error occurs during traversal, the iterator returns an
+                empty string `''` and the error object. On subsequent calls,
                 it consistently returns `nil` and the same error object.
 - `ctx:table`: a context table that contains the following fields:
     - `pathname:string`: the current pathname of the directory being traversed.
     - `depth:integer`: the current depth in the directory tree, starting from 1 for the root directory and incrementing for each subdirectory.
     - `follow_symlink:boolean`: whether symbolic links are followed.
+    - `toctou:boolean`: whether TOCTOU-safe traversal is enabled.
     - `error:any`: an error object if an error occurred during traversal.
     - `dirs:string[]`: a list of directories that will be traversed.
-    - `depths:integer[]`: a list of depths corresponding to the directories in `dirs`.    
+    - `depths:integer[]`: a list of depths corresponding to the directories in `dirs`.
     - `dir:dir`: a directory object that created by `lua-opendir` module.
         - https://github.com/mah0x211/lua-opendir
 
-**Example**
-
-the following example shows how to use the `walkdir` function to traverse a directory and print each entry:
+**Examples**
 
 ```lua
 local walkdir = require('walkdir')
 
--- get an iterator function and context for traversing a /tmp directory
+-- iterate manually
 local iter, ctx = walkdir('/tmp', true)
 local pathname, err, entry, isdir, depth, stat = iter(ctx)
 while pathname do
     print(pathname, err, entry, isdir, depth, stat)
-    if err then
-        print('Error:', err)
-    end
-    -- read next entry
     pathname, err, entry, isdir, depth, stat = iter(ctx)
 end
 
--- or using a generic for loop
+-- or use a generic for loop
 for pathname, err, entry, isdir, depth, stat in walkdir('/tmp', true) do
     print(pathname, err, entry, isdir, depth, stat)
-    if err then
-        print('Error:', err)
-    end
 end
-```
 
-Also, you can pass a `walkerfn` function to the `walkdir` function to control the traversal behavior
-
-### err = walkdir( pathname [, follow_symlink [, walkerfn]] )
-
-If `walkerfn` is provided, the function will traverse the directory and call the `walkerfn` for each entry.
-
-**Parameters**
-
-- `walkerfn:function`: a function that will be called for each entry in the directory.
-    ```
-    walkerfn(pathname:string, entry:string, isdir:boolean, depth:integer, stat:table):(skipdir:boolean, err:any)
-
-    Parameters:
-    * pathname  : the entry's pathname.
-    * entry     : the entry's name.
-    * isdir     : whether the entry is a directory.
-    * depth     : the depth of the entry in the directory tree, starting from 1 
-                  for the root directory and incrementing for each subdirectory.
-    * stat      : a table containing file status information (e.g., size, 
-                  modification time). if fail to get the file stat, it contains 
-                  an `error` field with the error object.
-
-    Returns:
-    * skipdir   : If `true`, the directory will not be traversed further, 
-                  otherwise it will be traversed.
-    * err       : an error object if an error occurred during traversal. If an 
-                  error returned, the traversal will stop and the error will be 
-                  returned by the `walkdir` function.
-    ```
-
-**Returns**
-
-- `err:any`: an error object if an error occurred during traversal. If no error occurred, it returns `nil`.
-
-**Example**
-
-the following example shows how to use the `walkdir` function to traverse a directory and call a `walkerfn` for each entry:
-
-```lua
-local walkdir = require('walkdir')
-
--- traverse a /tmp directory and call the walker function for each entry
-local err = walkdir('/tmp', true, function(pathname, entry, isdir, depth, stat)
-    print(pathname, entry, isdir, depth, stat)
-    -- if the entry is a directory and only want to traverse directories up to depth 2
-    if isdir and depth == 2 then
-        -- skip traversing this directory
-        return true
-    end
-end)
-if err then
-    print('Error:', err)
+-- enable TOCTOU-safe traversal
+for pathname, err, entry, isdir in walkdir('/tmp', false, nil, true) do
+    print(pathname, err, entry, isdir)
 end
 ```
 

--- a/rockspecs/walkdir-dev-1.rockspec
+++ b/rockspecs/walkdir-dev-1.rockspec
@@ -14,7 +14,7 @@ dependencies = {
     "error >= 0.15.0",
     "errno >= 0.5.0",
     "fstat >= 0.2.3",
-    "opendir >= 0.2.2",
+    "opendir >= 0.3.0",
 }
 build = {
     type = "builtin",

--- a/test/walkdir_test.lua
+++ b/test/walkdir_test.lua
@@ -7,6 +7,7 @@ local walkdir = require('walkdir')
 
 local FIRST_ENTRY
 local ENTRIES = {}
+local SYMLINK_TESTDIR = './symlink_testdir'
 
 local function copy_entries()
     local copy = {}
@@ -49,6 +50,10 @@ function testcase.before_all()
     end
 
     FIRST_ENTRY = table.remove(ENTRIES, 1)
+
+    -- create a symlink to testdir for toctou tests
+    local ok = os.execute('ln -s testdir ' .. SYMLINK_TESTDIR)
+    assert(ok == true or ok == 0, 'failed to create symlink_testdir')
 end
 
 function testcase.after_all()
@@ -61,6 +66,8 @@ function testcase.after_all()
     if FIRST_ENTRY then
         assert(os.remove(FIRST_ENTRY))
     end
+
+    os.remove(SYMLINK_TESTDIR)
 end
 
 function testcase.call_iterator_function()
@@ -72,6 +79,7 @@ function testcase.call_iterator_function()
         pathname = nil,
         depth = nil,
         follow_symlink = true,
+        toctou = false,
         dirs = {
             './testdir',
         },
@@ -247,4 +255,55 @@ function testcase.throw_error_on_invalid_argument()
     -- test that throws error with non-boolean follow_symlink argument
     err = assert.throws(walkdir, './testdir', 123)
     assert.match(err, 'follow_symlink must be a boolean, got number')
+
+    -- test that throws error when walkerfn is not a function
+    err = assert.throws(walkdir, './testdir', true, 123)
+    assert.match(err, 'walkerfn must be a function, got number')
+
+    -- test that throws error with non-boolean toctou argument
+    err = assert.throws(walkdir, './testdir', false, nil, 123)
+    assert.match(err, 'toctou must be a boolean, got number')
+end
+
+function testcase.with_toctou_iterator()
+    -- test that walkdir passes toctou to opendir for real directories
+    local iter, ctx = walkdir('./testdir', false, nil, true)
+    assert.is_func(iter)
+    assert.is_true(ctx.toctou)
+
+    -- test that traversal works normally when no symlinks are in the path
+    local entries = copy_entries()
+    for pathname, err in iter, ctx do
+        assert.is_nil(err)
+        entries[pathname] = nil
+    end
+    assert.empty(entries)
+end
+
+function testcase.with_toctou_and_walkerfn()
+    -- test that toctou works together with a walkerfn
+    local entries = copy_entries()
+    local err = walkdir('./testdir', false, function(pathname)
+        entries[pathname] = nil
+    end, true)
+    assert.is_nil(err)
+    assert.empty(entries)
+end
+
+function testcase.toctou_rejects_intermediate_symlink()
+    -- test that toctou=false follows an intermediate symlink (default behavior):
+    -- symlink_testdir is a symlink to testdir, so symlink_testdir/foo is
+    -- reachable via an intermediate symlink
+    local iter, ctx = walkdir(SYMLINK_TESTDIR .. '/foo', false, nil, false)
+    local pathname, err = iter(ctx)
+    assert.is_nil(err)
+    assert.is_string(pathname)
+
+    -- test that toctou=true rejects an intermediate symlink:
+    -- opendir(symlink_testdir/foo, false, true) fails because symlink_testdir
+    -- is a symlink at an intermediate position in the path
+    iter, ctx = walkdir(SYMLINK_TESTDIR .. '/foo', false, nil, true)
+    pathname, err = iter(ctx)
+    assert.equal(pathname, '')
+    assert.match(err, 'ENOTDIR')
 end

--- a/walkdir.lua
+++ b/walkdir.lua
@@ -56,6 +56,7 @@ end
 --- @field dirs string[]
 --- @field depths integer[]
 --- @field follow_symlink boolean
+--- @field toctou boolean
 --- @field pathname string?
 --- @field depth integer?
 --- @field dir dir?
@@ -82,7 +83,7 @@ local function open_next_dir(ctx)
     ctx.depths[#ctx.depths] = nil
 
     -- open the directory
-    local dir, err = opendir(ctx.pathname, ctx.follow_symlink)
+    local dir, err = opendir(ctx.pathname, ctx.follow_symlink, ctx.toctou)
     if dir then
         ctx.dir = dir
         return dir
@@ -208,9 +209,10 @@ end
 --- @param pathname string
 --- @param follow_symlink boolean?
 --- @param walkerfn walkdir.walkerfn?
+--- @param toctou boolean?
 --- @return walkdir.iterator|any
 --- @return walkdir.context?
-local function walkdir(pathname, follow_symlink, walkerfn)
+local function walkdir(pathname, follow_symlink, walkerfn, toctou)
     if type(pathname) ~= 'string' or find(pathname, '^%s*$') then
         fatalf(2, 'pathname must be a non-empty string, got %s', type(pathname))
     elseif follow_symlink ~= nil and type(follow_symlink) ~= 'boolean' then
@@ -218,6 +220,8 @@ local function walkdir(pathname, follow_symlink, walkerfn)
                type(follow_symlink))
     elseif walkerfn ~= nil and type(walkerfn) ~= 'function' then
         fatalf(2, 'walkerfn must be a function, got %s', type(walkerfn))
+    elseif toctou ~= nil and type(toctou) ~= 'boolean' then
+        fatalf(2, 'toctou must be a boolean, got %s', type(toctou))
     end
 
     -- remove double slashes and trailing slashes
@@ -235,6 +239,7 @@ local function walkdir(pathname, follow_symlink, walkerfn)
             1,
         },
         follow_symlink = follow_symlink == true,
+        toctou = toctou == true,
     }
 
     if walkerfn then


### PR DESCRIPTION
This pull request adds support for TOCTOU-safe directory traversal to the `walkdir` module, allowing users to prevent time-of-check/time-of-use race conditions when traversing directories. It introduces a new `toctou` parameter to both the iterator and callback forms of `walkdir`, updates the documentation to reflect these changes, and adds comprehensive tests to ensure correct behavior and error handling.

**TOCTOU-safe traversal support:**

* Added a `toctou` boolean parameter to the `walkdir` API, which, when enabled, uses `openat(2)` for each path segment to prevent TOCTOU race conditions. This is passed through to the underlying `opendir` call and is available in both iterator and callback forms. (`walkdir.lua`, `README.md`, [[1]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0R212-R224) [[2]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0R242) [[3]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0L85-R86) [[4]](diffhunk://#diff-e181efc5835a5819ad33f82014226b1102a6459dcd683c8dfaa9034f4ecd09f0R59) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-L104) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R166)

* Updated the `README.md` to document the new `toctou` option, provide usage examples for both iterator and callback styles, and explain its effect on symlink handling and TOCTOU safety. (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L30-L104) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L132-R166)

**Testing improvements:**

* Added tests to verify correct behavior when `toctou` is enabled, including tests for normal traversal, traversal with a walker function, and correct rejection of intermediate symlinks when `toctou` is true. (`test/walkdir_test.lua`, [test/walkdir_test.luaR258-R308](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4R258-R308))

* Added error handling tests for invalid argument types for `follow_symlink`, `walkerfn`, and `toctou`. (`test/walkdir_test.lua`, [test/walkdir_test.luaR258-R308](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4R258-R308))

* Enhanced test setup and teardown to create and clean up a symlinked directory used in TOCTOU-related tests. (`test/walkdir_test.lua`, [[1]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4R10) [[2]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4R53-R56) [[3]](diffhunk://#diff-dec14074122a3d470571d06969bc3d54aa3f742b0e2bd65d637181d01e730fb4R69-R70)

**Dependency update:**

* Updated the required version of the `opendir` dependency to `>= 0.3.0` in the rockspec to support the new TOCTOU feature. (`rockspecs/walkdir-dev-1.rockspec`, [rockspecs/walkdir-dev-1.rockspecL17-R17](diffhunk://#diff-13f6748c65d0ff3399aa5662344bca14e2c3e5f3e03316fb0d6d60f39be48b72L17-R17))

**CI workflow update:**

* Updated the GitHub Actions workflow to use a container image (`ghcr.io/mah0x211/lua-ci:latest`) that includes the necessary Lua environment, removing the need for the separate Lua setup step. (`.github/workflows/test.yml`, [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R12-L20) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R30-R31) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R41-L49)